### PR TITLE
fix: restore columns and filter on maximized start

### DIFF
--- a/src/gharqad/ui/mainwindow.cpp
+++ b/src/gharqad/ui/mainwindow.cpp
@@ -790,9 +790,6 @@ MainWindow::MainWindow(QWidget *parent)
         move(x, y);
       }
     }
-    if (Configs::windowSettings->maximized) {
-      showMaximized();
-    }
     Configs::tableSettings.Load(Configs::windowSettings);
   }
 
@@ -1765,7 +1762,11 @@ skip_updater_hide:
 
   if ((!Configs::dataStore->flag_tray) &&
       (!Configs::windowSettings->auto_hide)) {
-    show();
+    if (Configs::windowSettings->maximized) {
+      showMaximized();
+    } else {
+      show();
+    }
   } else {
     hide();
   }


### PR DESCRIPTION
## Bug

- When `maximized=true` in `window.ini`, table columns and filter row are invisible on startup

## Root Cause

- `showMaximized()` was called early in the constructor (geometry restore block, ~line 793)
- At that point, `FilterHeader` was not yet installed and table had no model
- Qt computed layout with an empty table and default `QHeaderView`
- After `FilterHeader` was installed later, layout was not recomputed, leaving columns and filter editors with zero size

## Fix

- Removed premature `showMaximized()` from geometry restore block
- Added maximized show logic to the existing show/hide block near end of constructor (~line 1765), right before `refresh_groups()`
- By that point: table model exists, `FilterHeader` is installed, model is set on the view
- `resize()` / `move()` calls remain in geometry block to store "normal" geometry for unmaximize