### PR TITLE
fix: avoid crash when traffic profile is missing

### DIFF
--- a/src/gharqad/ui/mainwindow_rpc.cpp
+++ b/src/gharqad/ui/mainwindow_rpc.cpp
@@ -863,7 +863,9 @@ void MainWindow::profile_stop(bool crash, bool block, bool manual) {
     Stats::trafficLooper->UpdateAll();
     for (const auto &item: Stats::trafficLooper->items) {
         if (item->id < 0) continue;
-        Configs::profileManager->GetProfile(item->id)->Save();
+        auto profile = Configs::profileManager->GetProfile(item->id);
+        if (profile == nullptr) continue;
+        profile->Save();
         refresh_proxy_list(item->id);
     }
     Stats::trafficLooper->loop_mutex.unlock();


### PR DESCRIPTION
## What

Check the result of `ProfileManager::GetProfile()` before saving traffic data during `MainWindow::profile_stop()`.

## Why

`GetProfile()` returns `nullptr` when a traffic item refers to a missing or invalid profile ID. The stop/exit path dereferenced that result unconditionally, so stopping a profile or closing NekoBox could crash in `JsonStore::Save()`.

## Testing

- Reproduced on Windows with a traffic item whose profile ID no longer resolves.
- Verified the affected build no longer crashes when stopping the profile or exiting.
- Built `src/gharqad/ui/mainwindow_rpc.cpp` successfully.
- Confirmed TUN behavior is unchanged.