### PR TITLE
Add Routes tab for per-application and per-domain routing

### DIFF
--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -4444,6 +4444,11 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <translation>График соединения</translation>
     </message>
     <message>
+        <location filename="../../src/nekobox/ui/mainwindow.ui" line="615" />
+        <source>Routes</source>
+        <translation>Маршруты</translation>
+    </message>
+    <message>
         <location filename="../../src/gharqad/ui/mainwindow.cpp" line="5190" />
         <source>Failed to download update assets</source>
         <translation>Не удалось загрузить обновлённые ресурсы</translation>
@@ -5212,6 +5217,99 @@ Request payload was: %2</source>
         <location filename="../../src/gharqad/main.cpp" line="190" />
         <source>Copy Link Location</source>
         <translation type="unfinished">Копировать расположение ссылки</translation>
+    </message>
+</context>
+<context>
+    <name>QuickRoutesWidget</name>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="33" />
+        <source>Applications</source>
+        <translation>Приложения</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="33" />
+        <source>Application</source>
+        <translation>Приложение</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="34" />
+        <source>Domains</source>
+        <translation>Домены</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="34" />
+        <source>Domain</source>
+        <translation>Домен</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="40" />
+        <source>Saved routes are applied after the core restarts.</source>
+        <translation>Сохранённые маршруты применяются после перезапуска ядра.</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="44" />
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="63" />
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="64" />
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="94" />
+        <source>Outbound</source>
+        <translation>Outbound</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="108" />
+        <source>proxy</source>
+        <translation>proxy</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="109" />
+        <source>direct</source>
+        <translation>direct</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="110" />
+        <source>block</source>
+        <translation>block</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="148" />
+        <source>Missing outbound (%1)</source>
+        <translation>Недоступный outbound (%1)</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="163" />
+        <source>Select an application</source>
+        <translation>Выберите приложение</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="165" />
+        <source>Applications (*.exe);;All files (*.*)</source>
+        <translation>Приложения (*.exe);;Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="186" />
+        <source>Full path to an .exe, or just its file name</source>
+        <translation>Полный путь к .exe или только имя файла</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="226" />
+        <source>Domain keyword, for example: example.com</source>
+        <translation>Ключевое слово домена, например: example.com</translation>
+    </message>
+    <message>
+        <location filename="../../src/gharqad/ui/setting/QuickRoutesWidget.cpp" line="296" />
+        <source>[Routes] Saved %1 application and %2 domain routes</source>
+        <translation>[Маршруты] Сохранено маршрутов: приложений — %1, доменов — %2</translation>
     </message>
 </context>
 <context>

--- a/src/gharqad/configs/ConfigBuilder.cpp
+++ b/src/gharqad/configs/ConfigBuilder.cpp
@@ -941,6 +941,108 @@ static void AppendMissingRuleSet(QJsonObject &route, const QJsonObject &ruleSet)
   route["rule_set"] = ruleSets;
 }
 
+// Rules of the "Routes" tab. Entries sharing an outbound are merged into one rule,
+// process paths and process names have to stay in separate rules because sing-box
+// requires every field of a rule to match at once.
+static QList<std::shared_ptr<RouteRule>> BuildQuickRouteRules() {
+  QList<std::shared_ptr<RouteRule>> rules;
+  if (dataStore->routing == nullptr ||
+      dataStore->routing->quick_routes == nullptr) {
+    return rules;
+  }
+  auto quick = dataStore->routing->quick_routes;
+
+  QList<int> outboundOrder;
+  QMap<int, QList<QString>> processPaths;
+  QMap<int, QList<QString>> processNames;
+  QMap<int, QList<QString>> domainKeywords;
+
+  // A route whose profile got deleted is dropped instead of failing the whole build.
+  auto accept = [&outboundOrder](const QString &match, int outbound) {
+    if (outbound >= 0 &&
+        (profileManager == nullptr ||
+         profileManager->GetProfile(outbound) == nullptr)) {
+      if (MW_show_log) {
+        MW_show_log("[Routes] Skipped \"" + match +
+                    "\", its outbound no longer exists");
+      }
+      return false;
+    }
+    if (!outboundOrder.contains(outbound)) {
+      outboundOrder.append(outbound);
+    }
+    return true;
+  };
+
+  const auto processCount =
+      qMin(quick->process_match.size(), quick->process_outbound.size());
+  for (qsizetype i = 0; i < processCount; i++) {
+    const auto value = quick->process_match[i].trimmed();
+    if (value.isEmpty()) {
+      continue;
+    }
+    const auto outbound = quick->process_outbound[i];
+    if (!accept(value, outbound)) {
+      continue;
+    }
+    if (value.contains(u'/') || value.contains(u'\\')) {
+      processPaths[outbound] << QDir::toNativeSeparators(value);
+    } else {
+      processNames[outbound] << value;
+    }
+  }
+  const auto domainCount =
+      qMin(quick->domain_match.size(), quick->domain_outbound.size());
+  for (qsizetype i = 0; i < domainCount; i++) {
+    const auto value = quick->domain_match[i].trimmed();
+    if (value.isEmpty()) {
+      continue;
+    }
+    const auto outbound = quick->domain_outbound[i];
+    if (!accept(value, outbound)) {
+      continue;
+    }
+    domainKeywords[outbound] << value;
+  }
+
+  auto makeRule = [](const QString &name, int outbound) {
+    auto rule = std::make_shared<RouteRule>();
+    rule->name = name;
+    rule->action = "route";
+    rule->outboundID = outbound;
+    return rule;
+  };
+
+  for (const auto &outbound : outboundOrder) {
+    if (processPaths.contains(outbound)) {
+      auto rule = makeRule("Quick routes: application paths", outbound);
+      rule->process_path = processPaths[outbound];
+      rules << rule;
+    }
+    if (processNames.contains(outbound)) {
+      auto rule = makeRule("Quick routes: application names", outbound);
+      rule->process_name = processNames[outbound];
+      rules << rule;
+    }
+  }
+  for (const auto &outbound : outboundOrder) {
+    if (domainKeywords.contains(outbound)) {
+      auto rule = makeRule("Quick routes: domains", outbound);
+      rule->domain_keyword = domainKeywords[outbound];
+      rules << rule;
+    }
+  }
+  return rules;
+}
+
+// Quick routes are matched before the rules of the active routing profile.
+static void PrependQuickRouteRules(std::shared_ptr<RoutingChain> &routeChain) {
+  const auto quickRules = BuildQuickRouteRules();
+  for (auto it = quickRules.crbegin(); it != quickRules.crend(); ++it) {
+    routeChain->Rules.prepend(*it);
+  }
+}
+
 static QJsonArray BuildNekoboxTunRulesForFullConfig(
     const std::shared_ptr<BuildConfigStatus> &status, QJsonObject &config) {
   auto routeChain =
@@ -949,13 +1051,17 @@ static QJsonArray BuildNekoboxTunRulesForFullConfig(
     return {};
   }
 
+  // copy for modification
+  routeChain = std::make_shared<RoutingChain>(*routeChain);
+  PrependQuickRouteRules(routeChain);
+
   std::map<int, QString> outboundMap;
   outboundMap[proxyID] = "proxy";
   outboundMap[directID] = "direct";
   outboundMap[blockID] = "block";
 
   for (auto item : *routeChain->get_used_outbounds()) {
-    if (item < 0) {
+    if (item < 0 || outboundMap.count(item) > 0) {
       continue;
     }
     auto neededEnt = profileManager->GetProfile(item);
@@ -1279,6 +1385,9 @@ void BuildConfigSingBox(const std::shared_ptr<BuildConfigStatus> &status) {
 
   // copy for modification
   routeChain = std::make_shared<RoutingChain>(*routeChain);
+  if (!blockAll) {
+    PrependQuickRouteRules(routeChain);
+  }
 
   // Direct domains
   bool needDirectDnsRules = false;
@@ -1492,7 +1601,7 @@ skip_multiple_jobs:
     outboundMap[blockID] = "block";
     int suffix = 0;
     for (const auto &item : *neededOutbounds) {
-      if (item < 0)
+      if (item < 0 || outboundMap.count(item) > 0)
         continue;
       auto neededEnt = profileManager->GetProfile(item);
       if (neededEnt == nullptr) {

--- a/src/gharqad/dataStore/Configs.cpp
+++ b/src/gharqad/dataStore/Configs.cpp
@@ -408,6 +408,22 @@ QByteArray hash = QCryptographicHash::hash(
         ADD_MAP("block", block, stringlist);
     STOP_MAP
 
+    DECL_MAP(QuickRoutes)
+        ADD_MAP("process_match", process_match, stringlist);
+        ADD_MAP("process_outbound", process_outbound, intList);
+        ADD_MAP("domain_match", domain_match, stringlist);
+        ADD_MAP("domain_outbound", domain_outbound, intList);
+    STOP_MAP
+
+    void QuickRoutes::normalize() {
+        auto fit = [](const QStringList &match, QList<int> &outbound) {
+            while (outbound.size() < match.size()) outbound.append(Configs::proxyID);
+            while (outbound.size() > match.size()) outbound.removeLast();
+        };
+        fit(process_match, process_outbound);
+        fit(domain_match, domain_outbound);
+    }
+
     DECL_MAP(DataStore)
         ADD_MAP("sub_custom_hwid_params", sub_custom_hwid_params, string);
         ADD_MAP("user_agent2", user_agent, string);
@@ -558,6 +574,7 @@ QByteArray hash = QCryptographicHash::hash(
         ADD_MAP("dns_final_out_direct", dns_final_out_direct, boolean);
 
         ADD_MAP("tun_split", tun_split, jsonStore);
+        ADD_MAP("quick_routes", quick_routes, jsonStore);
     STOP_MAP
 
     #undef d_add

--- a/src/gharqad/ui/mainwindow.cpp
+++ b/src/gharqad/ui/mainwindow.cpp
@@ -1195,6 +1195,10 @@ skip_updater_hide:
   // setup Speed Chart
   speedChartWidget = new SpeedWidget(this);
   ui->graph_tab->layout()->addWidget(speedChartWidget);
+
+  // setup Routes tab
+  quickRoutesWidget = new QuickRoutesWidget(this);
+  ui->routes_tab->layout()->addWidget(quickRoutesWidget);
 /*
   // table UI
   ui->proxyListTable->rowsSwapped = [=, this](int row1, int row2) {

--- a/src/gharqad/ui/setting/QuickRoutesWidget.cpp
+++ b/src/gharqad/ui/setting/QuickRoutesWidget.cpp
@@ -1,0 +1,322 @@
+#include <nekobox/ui/setting/QuickRoutesWidget.h>
+
+#include <nekobox/dataStore/DataStore.hpp>
+#include <nekobox/dataStore/Database.hpp>
+#include <nekobox/dataStore/ResourceEntity.hpp>
+#include <nekobox/dataStore/RouteEntity.h>
+#include <nekobox/global/GuiUtils.hpp>
+
+#include <QComboBox>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QSplitter>
+#include <QTableWidget>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+#include <algorithm>
+
+QuickRoutesWidget::QuickRoutesWidget(QWidget *parent) : QWidget(parent) {
+    auto *root = new QVBoxLayout(this);
+    root->setContentsMargins(4, 4, 4, 4);
+    root->setSpacing(6);
+
+    auto *splitter = new QSplitter(Qt::Vertical, this);
+    splitter->setChildrenCollapsible(false);
+    splitter->addWidget(makeSection(tr("Applications"), &processTable, tr("Application"), true));
+    splitter->addWidget(makeSection(tr("Domains"), &domainTable, tr("Domain"), false));
+    splitter->setStretchFactor(0, 1);
+    splitter->setStretchFactor(1, 1);
+    root->addWidget(splitter, 1);
+
+    auto *saveRow = new QHBoxLayout();
+    auto *hint = new QLabel(tr("Saved routes are applied after the core restarts."));
+    hint->setEnabled(false);
+    saveRow->addWidget(hint);
+    saveRow->addStretch();
+    saveButton = new QPushButton(tr("Save"));
+    saveRow->addWidget(saveButton);
+    root->addLayout(saveRow);
+
+    connect(saveButton, &QPushButton::clicked, this, [this] { saveToStore(); });
+
+    loadFromStore();
+}
+
+QWidget *QuickRoutesWidget::makeSection(const QString &title, QTableWidget **table,
+                                        const QString &firstHeader, bool processSection) {
+    auto *section = new QWidget();
+    auto *layout = new QVBoxLayout(section);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(4);
+
+    auto *header = new QHBoxLayout();
+    header->addWidget(new QLabel(title));
+    header->addStretch();
+    auto *addButton = new QPushButton(tr("Add"));
+    auto *removeButton = new QPushButton(tr("Remove"));
+    header->addWidget(addButton);
+    header->addWidget(removeButton);
+    layout->addLayout(header);
+
+    auto *created = new QTableWidget(0, 2, section);
+    setupTable(created, firstHeader);
+    layout->addWidget(created, 1);
+    *table = created;
+
+    connect(addButton, &QPushButton::clicked, this, [this, processSection] {
+        if (processSection) {
+            addProcessRow(browseForExecutable(), Configs::proxyID);
+        } else {
+            addDomainRow({}, Configs::proxyID);
+        }
+    });
+    connect(removeButton, &QPushButton::clicked, this,
+            [created] { removeSelectedRows(created); });
+
+    return section;
+}
+
+void QuickRoutesWidget::showEvent(QShowEvent *event) {
+    QWidget::showEvent(event);
+    refreshOutboundCombos();
+}
+
+void QuickRoutesWidget::setupTable(QTableWidget *table, const QString &firstHeader) {
+    table->setHorizontalHeaderLabels({firstHeader, tr("Outbound")});
+    table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Interactive);
+    table->horizontalHeader()->setHighlightSections(false);
+    table->verticalHeader()->setVisible(false);
+    table->setColumnWidth(1, 200);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->setAlternatingRowColors(true);
+}
+
+QList<QuickRoutesWidget::OutboundChoice> QuickRoutesWidget::collectOutbounds() {
+    QList<OutboundChoice> list;
+    list.append({Configs::proxyID, tr("proxy")});
+    list.append({Configs::directID, tr("direct")});
+    list.append({Configs::blockID, tr("block")});
+
+    if (Configs::profileManager == nullptr) {
+        return list;
+    }
+    for (const auto &gid : Configs::profileManager->groupsTabOrder) {
+        auto group = Configs::profileManager->GetGroup(gid);
+        if (group == nullptr) {
+            continue;
+        }
+        for (const auto &pid : group->profiles) {
+            auto profile = Configs::profileManager->GetProfile(pid);
+            if (profile == nullptr) {
+                continue;
+            }
+            auto name = profile->DisplayName();
+            if (!group->name.isEmpty()) {
+                name = group->name + " / " + name;
+            }
+            list.append({pid, name});
+        }
+    }
+    return list;
+}
+
+void QuickRoutesWidget::fillOutboundCombo(QComboBox *combo, const QList<OutboundChoice> &choices,
+                                          int selectedId) const {
+    combo->clear();
+    int selectedIndex = 0;
+    bool found = false;
+    for (const auto &choice : choices) {
+        combo->addItem(choice.name, choice.id);
+        if (choice.id == selectedId) {
+            selectedIndex = combo->count() - 1;
+            found = true;
+        }
+    }
+    if (!found) {
+        combo->addItem(tr("Missing outbound (%1)").arg(selectedId), selectedId);
+        selectedIndex = combo->count() - 1;
+    }
+    combo->setCurrentIndex(selectedIndex);
+}
+
+QComboBox *QuickRoutesWidget::makeOutboundCombo(int selectedId) const {
+    auto *combo = new QComboBox();
+    combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    fillOutboundCombo(combo, collectOutbounds(), selectedId);
+    return combo;
+}
+
+QString QuickRoutesWidget::browseForExecutable() {
+    QString startPath;
+    if (Configs::resourceManager != nullptr) {
+        startPath = Configs::resourceManager->getLatestPath();
+    }
+    const auto selected = QFileDialog::getOpenFileName(this, tr("Select an application"), startPath,
+#ifdef Q_OS_WIN
+                                                       tr("Applications (*.exe);;All files (*.*)")
+#else
+                                                       QString()
+#endif
+    );
+    if (selected.isEmpty()) {
+        return {};
+    }
+    if (Configs::resourceManager != nullptr) {
+        Configs::resourceManager->latest_path = QFileInfo(selected).absolutePath();
+    }
+    return QDir::toNativeSeparators(selected);
+}
+
+QWidget *QuickRoutesWidget::makeProcessEditor(const QString &path) {
+    auto *holder = new QWidget();
+    auto *layout = new QHBoxLayout(holder);
+    layout->setContentsMargins(2, 0, 2, 0);
+    layout->setSpacing(4);
+
+    auto *edit = new QLineEdit(path);
+    edit->setObjectName("process_path");
+    edit->setPlaceholderText(tr("Full path to an .exe, or just its file name"));
+    auto *browse = new QToolButton();
+    browse->setText("...");
+    browse->setToolTip(tr("Select an application"));
+
+    connect(browse, &QToolButton::clicked, holder, [this, edit] {
+        const auto selected = browseForExecutable();
+        if (!selected.isEmpty()) {
+            edit->setText(selected);
+        }
+    });
+
+    layout->addWidget(edit, 1);
+    layout->addWidget(browse);
+    return holder;
+}
+
+QString QuickRoutesWidget::processPathAt(int row) const {
+    auto *holder = processTable->cellWidget(row, 0);
+    if (holder == nullptr) {
+        return {};
+    }
+    auto *edit = holder->findChild<QLineEdit *>("process_path");
+    return edit != nullptr ? edit->text().trimmed() : QString();
+}
+
+int QuickRoutesWidget::outboundAt(QTableWidget *table, int row) {
+    auto *combo = qobject_cast<QComboBox *>(table->cellWidget(row, 1));
+    if (combo == nullptr) {
+        return Configs::proxyID;
+    }
+    return combo->currentData().toInt();
+}
+
+void QuickRoutesWidget::addProcessRow(const QString &path, int outboundId) {
+    const int row = processTable->rowCount();
+    processTable->insertRow(row);
+    processTable->setCellWidget(row, 0, makeProcessEditor(path));
+    processTable->setCellWidget(row, 1, makeOutboundCombo(outboundId));
+}
+
+void QuickRoutesWidget::addDomainRow(const QString &domain, int outboundId) {
+    const int row = domainTable->rowCount();
+    domainTable->insertRow(row);
+    auto *edit = new QLineEdit(domain);
+    edit->setPlaceholderText(tr("Domain keyword, for example: example.com"));
+    domainTable->setCellWidget(row, 0, edit);
+    domainTable->setCellWidget(row, 1, makeOutboundCombo(outboundId));
+}
+
+void QuickRoutesWidget::removeSelectedRows(QTableWidget *table) {
+    auto rows = table->selectionModel()->selectedRows();
+    std::sort(rows.begin(), rows.end(),
+              [](const QModelIndex &a, const QModelIndex &b) { return a.row() > b.row(); });
+    for (const auto &index : rows) {
+        table->removeRow(index.row());
+    }
+}
+
+void QuickRoutesWidget::refreshOutboundCombos() {
+    const auto choices = collectOutbounds();
+    auto updateTable = [&](QTableWidget *table) {
+        for (int row = 0; row < table->rowCount(); row++) {
+            auto *combo = qobject_cast<QComboBox *>(table->cellWidget(row, 1));
+            if (combo == nullptr) {
+                continue;
+            }
+            const auto selected = combo->currentData().toInt();
+            QSignalBlocker blocker(combo);
+            fillOutboundCombo(combo, choices, selected);
+        }
+    };
+    updateTable(processTable);
+    updateTable(domainTable);
+}
+
+void QuickRoutesWidget::loadFromStore() {
+    processTable->setRowCount(0);
+    domainTable->setRowCount(0);
+    if (Configs::dataStore == nullptr || Configs::dataStore->routing == nullptr ||
+        Configs::dataStore->routing->quick_routes == nullptr) {
+        return;
+    }
+    auto routes = Configs::dataStore->routing->quick_routes;
+    routes->normalize();
+    for (int i = 0; i < routes->process_match.size(); i++) {
+        addProcessRow(routes->process_match[i], routes->process_outbound[i]);
+    }
+    for (int i = 0; i < routes->domain_match.size(); i++) {
+        addDomainRow(routes->domain_match[i], routes->domain_outbound[i]);
+    }
+}
+
+void QuickRoutesWidget::saveToStore() {
+    if (Configs::dataStore == nullptr || Configs::dataStore->routing == nullptr ||
+        Configs::dataStore->routing->quick_routes == nullptr) {
+        return;
+    }
+    auto routes = Configs::dataStore->routing->quick_routes;
+    routes->process_match.clear();
+    routes->process_outbound.clear();
+    routes->domain_match.clear();
+    routes->domain_outbound.clear();
+
+    for (int row = 0; row < processTable->rowCount(); row++) {
+        const auto path = processPathAt(row);
+        if (path.isEmpty()) {
+            continue;
+        }
+        routes->process_match.append(path);
+        routes->process_outbound.append(outboundAt(processTable, row));
+    }
+    for (int row = 0; row < domainTable->rowCount(); row++) {
+        auto *edit = qobject_cast<QLineEdit *>(domainTable->cellWidget(row, 0));
+        const auto domain = edit != nullptr ? edit->text().trimmed() : QString();
+        if (domain.isEmpty()) {
+            continue;
+        }
+        routes->domain_match.append(domain);
+        routes->domain_outbound.append(outboundAt(domainTable, row));
+    }
+
+    Configs::dataStore->routing->Save();
+
+    if (MW_show_log) {
+        MW_show_log(tr("[Routes] Saved %1 application and %2 domain routes")
+                        .arg(routes->process_match.size())
+                        .arg(routes->domain_match.size()));
+    }
+    if (MW_dialog_message) {
+        MW_dialog_message("", "UpdateDataStore,RouteChanged");
+    }
+}

--- a/src/nekobox/dataStore/DataStore.hpp
+++ b/src/nekobox/dataStore/DataStore.hpp
@@ -27,6 +27,23 @@ namespace Configs {
         QStringList proxy, direct, block;
     };
 
+    // Per-application and per-domain routes edited from the "Routes" tab of the main window.
+    // Outbound values are RouteRule outbound ids: negative sentinels or a profile id.
+    class QuickRoutes: public JsonStore {
+        public:
+
+        DECLARE_STORE_TYPE(NoSave)
+        virtual ConfJsMap _map() override;
+
+        QStringList process_match;
+        QList<int> process_outbound;
+        QStringList domain_match;
+        QList<int> domain_outbound;
+
+        // Keeps every match list and its outbound list the same length.
+        void normalize();
+    };
+
     enum DatabaseType {
         json_type = 1,
         binary_type = 2,
@@ -78,6 +95,7 @@ namespace Configs {
         int ruleset_mirror = Configs::Mirrors::CLOUDFLARE;
 
         std::shared_ptr<TunSplit> tun_split = std::make_shared<TunSplit>();
+        std::shared_ptr<QuickRoutes> quick_routes = std::make_shared<QuickRoutes>();
 
         explicit Routing(int preset = 0);
 

--- a/src/nekobox/ui/mainwindow.h
+++ b/src/nekobox/ui/mainwindow.h
@@ -18,6 +18,7 @@
 #include <nekobox/stats/connections/connectionLister.hpp>
 #include <nekobox/stats/autotester/ProxyAutoTester.hpp>
 #include <3rdparty/qv2ray/v2/ui/widgets/speedchart/SpeedWidget.hpp>
+#include <nekobox/ui/setting/QuickRoutesWidget.h>
 
 #ifdef Q_OS_UNIX
 #include <QtDBus>
@@ -398,6 +399,7 @@ private:
     int toolTipID;
     //
     SpeedWidget *speedChartWidget;
+    QuickRoutesWidget *quickRoutesWidget;
     //
     // for data view
     QString softwarePath;

--- a/src/nekobox/ui/mainwindow.ui
+++ b/src/nekobox/ui/mainwindow.ui
@@ -610,6 +610,31 @@ QToolButton::menu-indicator {
          </property>
         </layout>
        </widget>
+       <widget class="QWidget" name="routes_tab">
+        <attribute name="title">
+         <string>Routes</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+         </property>
+         <property name="leftMargin">
+          <number>1</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>1</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
+       </widget>
       </widget>
      </widget>
     </item>

--- a/src/nekobox/ui/setting/QuickRoutesWidget.h
+++ b/src/nekobox/ui/setting/QuickRoutesWidget.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <QWidget>
+
+QT_BEGIN_NAMESPACE
+class QComboBox;
+class QLineEdit;
+class QPushButton;
+class QTableWidget;
+QT_END_NAMESPACE
+
+class QuickRoutesWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit QuickRoutesWidget(QWidget *parent = nullptr);
+
+protected:
+    void showEvent(QShowEvent *event) override;
+
+private:
+    struct OutboundChoice {
+        int id;
+        QString name;
+    };
+
+    QTableWidget *processTable = nullptr;
+    QTableWidget *domainTable = nullptr;
+    QPushButton *saveButton = nullptr;
+
+    QWidget *makeSection(const QString &title, QTableWidget **table, const QString &firstHeader,
+                         bool processSection);
+
+    static void setupTable(QTableWidget *table, const QString &firstHeader);
+
+    static QList<OutboundChoice> collectOutbounds();
+
+    void fillOutboundCombo(QComboBox *combo, const QList<OutboundChoice> &choices, int selectedId) const;
+
+    QComboBox *makeOutboundCombo(int selectedId) const;
+
+    QWidget *makeProcessEditor(const QString &path);
+
+    [[nodiscard]] QString processPathAt(int row) const;
+
+    [[nodiscard]] static int outboundAt(QTableWidget *table, int row);
+
+    void addProcessRow(const QString &path, int outboundId);
+
+    void addDomainRow(const QString &domain, int outboundId);
+
+    static void removeSelectedRows(QTableWidget *table);
+
+    QString browseForExecutable();
+
+    void refreshOutboundCombos();
+
+    void loadFromStore();
+
+    void saveToStore();
+};


### PR DESCRIPTION
Routes live in the routing settings, so they stay in effect regardless of the selected routing profile, and are injected as rules ahead of that profile when the core config is built. Applying them requires a core restart, hence the explicit Save button.